### PR TITLE
Fix incorrect resource path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-kit-models",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "repository": "git@github.com:Vermonster/fhir-kit-models.git",
   "author": "Stephen MacVicar <smacvicar@vermonster.com>",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,7 +10,8 @@ const checkResourceType = resourceType => {
 
 const loadResource = resourceType => {
   checkResourceType(resourceType);
-  const resourcePath = `resources/${resourceType}`;
+  const resourcePath = `./${resourceType}`;
+  console.log(`loading ${resourcePath}`);
   try {
     return require(resourcePath); // eslint-disable-line import/no-dynamic-require
   } catch (_error) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,7 +11,6 @@ const checkResourceType = resourceType => {
 const loadResource = resourceType => {
   checkResourceType(resourceType);
   const resourcePath = `./${resourceType}`;
-  console.log(`loading ${resourcePath}`);
   try {
     return require(resourcePath); // eslint-disable-line import/no-dynamic-require
   } catch (_error) {

--- a/test/array-proxy-test.js
+++ b/test/array-proxy-test.js
@@ -8,16 +8,13 @@ describe('ArrayProxy', function () {
   let template;
 
   before(function () {
-    mock('./ArrayProxy', require('../src/ArrayProxy'));
-    mock('./helpers', require('../src/helpers'));
-
     template = loadResourceTemplates();
     const schema = JSON.parse(fs.readFileSync(path.normalize(`${__dirname}/fixtures/base-resource.json`)));
 
     generateClass(schema, 'tmp', template);
 
     BaseResource = require('../tmp/BaseResource');
-    mock('resources/BaseResource', require('../tmp/BaseResource'));
+    mock('../src/BaseResource', BaseResource);
   });
 
   after(function () {

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -61,7 +61,7 @@ describe('loadResource', function () {
   const testResource = { abc: '123' };
 
   before(function () {
-    mock('resources/TestResource', testResource);
+    mock('../src/TestResource', testResource);
   });
 
   after(function () {

--- a/test/resource-test.js
+++ b/test/resource-test.js
@@ -6,9 +6,6 @@ describe('Generated Resources', function () {
   let template;
 
   before(function () {
-    mock('../ArrayProxy', require('../src/ArrayProxy'));
-    mock('../helpers', require('../src/helpers'));
-
     template = loadResourceTemplates();
     const schema = JSON.parse(fs.readFileSync(path.normalize(`${__dirname}/fixtures/base-resource.json`)));
     generateClass(schema, 'tmp', template);


### PR DESCRIPTION
The helpers and resources are now in the same folder, so the require path in `loadResources` needed to be updated.